### PR TITLE
Fix typo in license

### DIFF
--- a/upx-license.html
+++ b/upx-license.html
@@ -81,7 +81,7 @@ GNU GENERAL PUBLIC LICENSE
 SPECIAL EXCEPTION FOR COMPRESSED EXECUTABLES
 ============================================
 
-   The stub which is imbedded in each UPX compressed program is part
+   The stub which is embedded in each UPX compressed program is part
    of UPX and UCL, and contains code that is under our copyright. The
    terms of the GNU General Public License still apply as compressing
    a program is a special form of linking with our stub.


### PR DESCRIPTION
imbedded is not a word